### PR TITLE
Rename libcef.dll to libce2.dll

### DIFF
--- a/articles/troubleshooting/client.md
+++ b/articles/troubleshooting/client.md
@@ -90,7 +90,7 @@ If Webview is not rendering in Linux, you might be missing required libraries in
 
 ##### Files to be copied into `/cef` directory
 
--   libcef.dll
+-   libce2.dll
 -   icudtl.dat
 -   snapshot_blob.bin
 -   chrome_elf.dll


### PR DESCRIPTION
libcef.dll has been renamed to libce2.dll but it's still mentioned as libcef.dll in troubleshooting.