### PR TITLE
fix: connection queue, early auth & cdn set to false

### DIFF
--- a/articles/configs/server.md
+++ b/articles/configs/server.md
@@ -101,7 +101,8 @@ tags: [
     "Freeroam",
     "Cool"
 ]
-# Enables the connection queue
+# Should connection queue be enabled for your server.
+# ConnectionQueueAdd & ConnectionQueueRemove serverside events are required to accept or decline connections
 connectionQueue: false
 # Should early auth be used for your server
 useEarlyAuth: false

--- a/articles/configs/server.md
+++ b/articles/configs/server.md
@@ -102,13 +102,13 @@ tags: [
     "Cool"
 ]
 # Enables the connection queue
-connectionQueue: "true"
+connectionQueue: false
 # Should early auth be used for your server
-useEarlyAuth: true
+useEarlyAuth: false
 # The url for the early auth login page (only used when useEarlyAuth is true)
 earlyAuthUrl: "https://example.com/login"
 # Should a CDN be used for your server
-useCdn: true
+useCdn: false
 # The url for the CDN page
 cdnUrl: "https://cdn.example.com"
 ```


### PR DESCRIPTION
Prevents errors due copy pasting the config without having everything set up