### PR TITLE
Remove inspect cli arg

### DIFF
--- a/articles/configs/server.md
+++ b/articles/configs/server.md
@@ -133,7 +133,7 @@ global-webcrypto = true
 # "https://nodejs.org/api/cli.html#--experimental-network-imports"
 network-imports = true
 # Add extra cli arguments to the node environment "https://nodejs.org/api/cli.html"
-extra-cli-args = ["--inspect=127.0.0.1:9229", "--max-old-space-size=8192"]
+extra-cli-args = ["--max-old-space-size=8192"]
 # Enable node.js inspector
 [js-module.inspector]
 host = "127.0.0.1"


### PR DESCRIPTION
CLI args for js inspector is not needed anymore as we now have config options for it.