### PR TITLE
feat: `skipCustomModuleWarning` config option

### DIFF
--- a/articles/configs/client.md
+++ b/articles/configs/client.md
@@ -32,7 +32,8 @@ After you downloaded and installed the alt:V Multiplayer client, you can find th
 |   linuxCompatibility      |   boolean(true/false) |   false              | Enable or disables Linux/MacOS related settings (See Discord #general [Linux](https://discord.com/channels/371265202378899476/988474811258908702) & [MacOS](https://discord.com/channels/371265202378899476/1105208952091840612) Threads) |
 |   discordRichPresence     |   boolean(true/false) |   true               | Enable or Disable the Discord Rich Presence ("Now Playing" alt:V in Discord user profile)                                                                                                                                                 |
 |   enableModDirectory      |   boolean(true/false) |   false              | Enables the mod directory. See [here](~/articles/troubleshooting/client-mods.md) for more info.                                                                                                                                           |
-|   cachePath      |   string |   "cache" directory in client folder             | Changes location of the cache directory where server assets (interiors, scripts, etc.) are being downloaded to.                                                                                                                                           |
+|   cachePath               |         string        |   "cache" directory in client folder | Changes location of the cache directory where server assets (interiors, scripts, etc.) are being downloaded to.                                                                                               |
+|   skipCustomModuleWarning |   boolean(true/false) |   false              | Skips "Do you want to load [module name]?" confirmation window. See [SDK](https://docs.altv.mp/sdk/index.html) for more info. |
 ## Example altv.toml file
 
 ```toml


### PR DESCRIPTION
also fixed formatting of `cachePath`