### PR TITLE
fix: downloads page url

### DIFF
--- a/articles/bytecode_module.md
+++ b/articles/bytecode_module.md
@@ -39,7 +39,7 @@ That array accepts the same paths as the `client-files` option does, so it is po
 ## Download
 
 The module can be downloaded from the following sources:
-1. [The official alt:V downloads page](https://altv.mp/#/downloads)
+1. [The official alt:V downloads page](https://altv.mp/downloads)
 2. The CDN directly - [Windows](http://cdn.alt-mp.com/js-bytecode-module/release/x64_win32/js-bytecode-module.dll) / [Linux](http://cdn.alt-mp.com/js-bytecode-module/release/x64_linux/libjs-bytecode-module.so)
 3. [The bytecode module releases page](https://github.com/altmp/altv-js-bytecode/releases)
 

--- a/articles/cdn_links.md
+++ b/articles/cdn_links.md
@@ -1,6 +1,6 @@
 # CDN Links
 
-Here you can find the CDN-Links(=Content Delivery Network) for the alt:V files. It's recommended to use the [Downloads-Page](https://altv.mp/#/downloads) where the files get automatically bundled for you.
+Here you can find the CDN-Links(=Content Delivery Network) for the alt:V files. It's recommended to use the [Downloads-Page](https://altv.mp/downloads) where the files get automatically bundled for you.
 
 Valid values for ${BRANCH} are: **release**, **rc** and **dev**.
 


### PR DESCRIPTION
As the downloads page was updated, the urls in the doc weren't changed